### PR TITLE
Update version to 5.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
   <groupId>ome</groupId>
   <artifactId>bio-formats-examples</artifactId>
-  <version>5.8.1-SNAPSHOT</version>
+  <version>5.8.1</version>
 
   <name>Bio-Formats examples</name>
   <description>Bio-Formats examples</description>
@@ -23,7 +23,7 @@
   </licenses>
 
   <properties>
-    <bioformats.version>5.8.1-SNAPSHOT</bioformats.version>
+    <bioformats.version>5.8.1</bioformats.version>
     <logback.version>1.1.1</logback.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->


### PR DESCRIPTION
This is the state of the examples kept in sync with the bioformats 5.8.1 release.  It should also be tagged (but not released), to mark this point in the history.

(We could release it if we wanted, but it's not necessary at this point.)