### PR TITLE
Add infrastructure to deploy on tags via Travis CI

### DIFF
--- a/.travis.settings.xml
+++ b/.travis.settings.xml
@@ -1,0 +1,13 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+      <server>
+        <id>ome.staging</id>
+        <username>${env.CI_DEPLOY_USER}</username>
+        <password>${env.CI_DEPLOY_PASS}</password>
+      </server>
+  </servers>
+</settings>
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,3 +40,12 @@ matrix:
   exclude:
     - jdk: oraclejdk10
       env: BUILD="gradle publishToMavenLocal"
+
+deploy:
+  provider: script
+  script: "cp .travis.settings.xml $HOME/.m2/settings.xml && mvn deploy"
+  skip_cleanup: true
+  on:
+    tags: true
+    jdk: oraclejdk8
+    condition: $BUILD = "mvn install"


### PR DESCRIPTION
- use Travis deployment mechanism https://docs.travis-ci.com/user/deployment/
to release the artifact to the OME artifactory.
- consume secret environment variables that should be set up at the Travis level
- only deploy for the Maven/JDK8 build

An example of consumption of this PR is done in https://travis-ci.org/sbesson/bio-formats-examples/builds/421584253 (with an additional commit bumping the version numbers to rc1). See notably the deployment logs for the [JDK8 Maven](https://travis-ci.org/sbesson/bio-formats-examples/jobs/421584255) component.