### PR TITLE
Bio-Formats examples 6.0.0 m4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ addons:
 
 jdk:
   - oraclejdk11
+  - openjdk11
   - oraclejdk8
-  - openjdk7
+  - openjdk8
 
 env:
   - BUILD="mvn install"
@@ -40,6 +41,8 @@ matrix:
   exclude:
     - jdk: oraclejdk11
       env: BUILD="gradle publishToMavenLocal exec"
+    - jdk: openjdk11
+      env: BUILD="gradle publishToMavenLocal exec"
 
 deploy:
   provider: script
@@ -47,5 +50,5 @@ deploy:
   skip_cleanup: true
   on:
     tags: true
-    jdk: oraclejdk8
+    jdk: openjdk8
     condition: $BUILD = "mvn install"

--- a/build.gradle
+++ b/build.gradle
@@ -16,9 +16,9 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-api', version: '6.0.0-m3'){}
-    compile(group: 'ome', name: 'formats-bsd', version: '6.0.0-m3'){}
-    compile(group: 'ome', name: 'formats-gpl', version: '6.0.0-m3'){}
+    compile(group: 'ome', name: 'formats-api', version: '6.0.0-m4'){}
+    compile(group: 'ome', name: 'formats-bsd', version: '6.0.0-m4'){}
+    compile(group: 'ome', name: 'formats-gpl', version: '6.0.0-m4'){}
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/pom.xml
+++ b/pom.xml
@@ -87,10 +87,10 @@
 	<groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>3.7.0</version>
-        <!-- Require the Java 7 platform. -->
+        <!-- Require the Java 8 platform. -->
         <configuration>
-          <source>1.7</source>
-          <target>1.7</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </licenses>
 
   <properties>
-    <bioformats.version>6.0.0-m3</bioformats.version>
+    <bioformats.version>6.0.0-m4</bioformats.version>
     <logback.version>1.1.1</logback.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->


### PR DESCRIPTION
- Consume `ome:formats-gpl:6.0.0-m4`
- Bump minimum Java version to 8
- Review environment tested by Travis to include OpenJDK 8 and 11
