### PR TITLE
Allow the example execution to be skipped

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,6 +154,7 @@
               <arguments>
                 <argument>test.fake</argument>
               </arguments>
+              <skip>${skipTests}</skip>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
Reported by @joshmoore who encountered the issue described in https://stackoverflow.com/a/37859061

With this change `mvn -DskipTests` on this component should not execute the examples (but compile them)