### PR TITLE
Remove unnecessary Unidata repository

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,23 +2,17 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 group = "ome"
-version = "6.1.0-m1"
+version = "6.3.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
-    maven {
-        name 'Unidata'
-        url 'https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases'
-    }
     maven {
         url 'https://artifacts.openmicroscopy.org/artifactory/maven/'
     }
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-api', version: '6.1.0-m1'){}
-    compile(group: 'ome', name: 'formats-bsd', version: '6.1.0-m1'){}
-    compile(group: 'ome', name: 'formats-gpl', version: '6.1.0-m1'){}
+    compile(group: 'ome', name: 'formats-gpl', version: '6.2.1'){}
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
   </licenses>
 
   <properties>
-    <formats-gpl.version>6.1.1</formats-gpl.version>
+    <formats-gpl.version>6.2.1</formats-gpl.version>
     <logback.version>1.1.1</logback.version>
 
     <!-- NB: Avoid platform encoding warning when copying resources. -->
@@ -202,7 +202,7 @@
     <connection>scm:git:git://github.com/ome/bio-formats-examples</connection>
     <developerConnection>scm:git:git@github.com:ome/bio-formats-examples</developerConnection>
     <tag>HEAD</tag>
-    <url>http://github.com/ome/bio-formats-examples</url>
+    <url>https://github.com/ome/bio-formats-examples</url>
   </scm>
 
   <!-- NB: for parent project -->
@@ -212,11 +212,6 @@
       <name>Central Repository</name>
       <url>https://repo.maven.apache.org/maven2</url>
     </repository>
-    <repository>
-      <id>unidata.releases</id>
-      <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases</url>
-      <snapshots><enabled>false</enabled></snapshots>
-      </repository>
     <repository>
       <id>ome</id>
       <name>OME Artifactory</name>


### PR DESCRIPTION
With the mirroring of the relevant artifacts, it should be sufficient to depend on OME Artifactory only