### PR TITLE
Use implementation rather than removed compile task in Gradle7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'java'
 apply plugin: 'maven-publish'
 
 group = "ome"
-version = "6.3.0-SNAPSHOT"
+version = "6.7.0-SNAPSHOT"
 
 repositories {
     mavenCentral()
@@ -12,7 +12,7 @@ repositories {
 }
 
 dependencies {
-    compile(group: 'ome', name: 'formats-gpl', version: '6.2.1'){}
+    implementation(group: 'ome', name: 'formats-gpl', version: '6.6.1'){}
 }
 
 task sourcesJar(type: Jar, dependsOn: classes) {


### PR DESCRIPTION
Also bump versions in `build.gradle`

Fixes the failing scheduled build (https://github.com/ome/bio-formats-examples/actions/runs/759588132) since Gradle 7 is now included by default