### PR TITLE
Matlab Examples

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -30,6 +30,5 @@ jobs:
         if: runner.os == 'macos'
         run: colima start
       - name: Run matlab tests
-        if: runner.os != 'windows'
         run: |
           docker run -t -v $(pwd)/src/:/src/ openmicroscopy/bio-formats-octave /src/main/matlab/bftest.m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -31,4 +31,5 @@ jobs:
         run: colima start
       - name: Run matlab tests
         run: |
+          #sed -i.bak '1s/^/pkg load bioformats\n /' src/main/matlab/bftest.m
           docker run -t -v $(pwd)/src/:/src/ openmicroscopy/bio-formats-octave /src/main/matlab/bftest.m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,35 @@
+# Run the tests
+---
+name: Test
+
+on: 
+  push:
+  pull_request:
+  schedule:
+    - cron: '0 0 * * 0'
+
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup docker
+        if: runner.os == 'macos'
+        run: |
+          brew install docker
+          brew install docker-compose
+      - name: Symlink (compose is now a cli-plugins)
+        if: runner.os == 'macos'
+        run: |
+          mkdir -p ~/.docker/cli-plugins
+          ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
+      - name: Start docker
+        if: runner.os == 'macos'
+        run: colima start
+      - name: Run matlab tests
+        if: runner.os != 'windows'
+        run: |
+          docker run -t openmicroscopy/bio-formats-octave src/main/matlab/bftest.m

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,4 +32,4 @@ jobs:
       - name: Run matlab tests
         if: runner.os != 'windows'
         run: |
-          docker run -t openmicroscopy/bio-formats-octave src/main/matlab/bftest.m
+          docker run -t -v $(pwd)/src/:/src/ openmicroscopy/bio-formats-octave /src/main/matlab/bftest.m

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
 target
 .idea
+.gradle

--- a/src/main/matlab/bftest.m
+++ b/src/main/matlab/bftest.m
@@ -1,3 +1,6 @@
+% Load Bio-Formats
+pkg load bioformats
+
 bfCheckJavaPath();
 
 % Create local file for testing


### PR DESCRIPTION
~This PR is built on top of #126 to avoid conflicts.~

This PR allows to run the matlab examples on MacOS and Ubuntu using the bf-octave docker image
It takes longer to run the test on Mac since docker needs to be installed.
~I can close #126 if we prefer to combine everything in one PR~
