### PR TITLE
Fix reST inclusion markers in ReadWriteInMemory example

### DIFF
--- a/src/main/java/ReadWriteInMemory.java
+++ b/src/main/java/ReadWriteInMemory.java
@@ -90,7 +90,7 @@ public class ReadWriteInMemory {
     System.out.println();
     System.out.println("Reading image data from memory...");
 
-    /* read-start */
+    /* reader-start */
     ServiceFactory factory = new ServiceFactory();
     OMEXMLService service = factory.getInstance(OMEXMLService.class);
     IMetadata omeMeta = service.createOMEXMLMetadata();
@@ -98,7 +98,7 @@ public class ReadWriteInMemory {
     ImageReader reader = new ImageReader();
     reader.setMetadataStore(omeMeta);
     reader.setId(inId);
-    /* read-end */
+    /* reader-end */
 
     int seriesCount = reader.getSeriesCount();
     int imageCount = reader.getImageCount();


### PR DESCRIPTION
Noticed during the testing of https://github.com/ome/bioformats/issues/4413. In https://bio-formats.readthedocs.io/en/v8.4.0/developers/in-memory.html#reading-file-from-memory, the same section of text is included twice.

The markers allow sections of the code to be included in the reStructuredText page of the Bio-Formats documentation via the literalinclude directive - see https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-literalinclude The directive options return the first line containing a particular value so the following directive
```
.. literalinclude:: examples/ReadWriteInMemory.java
   :language: java
   :start-after: read-start
   :end-before: read-end
```
returns the block between /* file-read-start */ and /* file-read-end */.

Fixing the documentation will require a corresponding PR against https://github.com/ome/bio-formats-documentation to use the new markers.